### PR TITLE
refactoring servicemodules into dataclasses and updating to python3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ factoids.db
 .idea/*
 .env
 modules/choose.py
+.pylintrc
+.venv

--- a/api/persistence.py
+++ b/api/persistence.py
@@ -3,7 +3,7 @@
 ###########################################################################
 
 
-class Persistence(object):
+class Persistence:
     def __init__(self, uri, user, api_key):
         self._uri = uri
         self._user = user

--- a/commentposter.py
+++ b/commentposter.py
@@ -13,7 +13,7 @@ spinner = cycle("\\|/-")
 log = get_logger()
 
 
-class CommentPoster(object):
+class CommentPoster:
     utils = None
 
     def __init__(self):

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: stampy
 channels:
   - defaults
 dependencies:
-  - python=3.9
+  - python=3.10
   - numpy
   - pip
   - sqlite

--- a/modules/module.py
+++ b/modules/module.py
@@ -77,7 +77,7 @@ class Response:
     a good response is, and how slow/expensive the callback function is.
     """
 
-    embed: discord.Embed = None
+    embed: Optional[discord.Embed] = None
     confidence: float = 0.0
     text: Union[str, Iterable[str]] = ""
     callback: Optional[Callable] = None
@@ -92,7 +92,7 @@ class Response:
         return bool(self.text) or bool(self.callback) or bool(self.confidence)
 
 
-class Module(object):
+class Module:
     utils = None
 
     def __init__(self):

--- a/utilities/serviceutils.py
+++ b/utilities/serviceutils.py
@@ -1,20 +1,19 @@
 from config import Services
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Optional
-from enum import Enum
 
-
+@dataclass(slots=True)
 class ServiceRole:
-    def __init__(self, name: str, id: str):
-        self.name = name
-        self.id = id
+    name: str
+    id: str
+    _role: object = field(default=None, init=False)
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, int):
             return self.id == other
-        if hasattr(self, "_role"):
-            if type(self._role) == type(other):
-                return self._role == other
+        if self._role is not None and type(self._role) == type(other):
+            return self._role == other
         if not isinstance(other, ServiceRole):
             return False
         return (self.id == other.id) and type(self) == type(other)
@@ -27,19 +26,19 @@ class ServiceRole:
         return hash(self.id) >> 22
 
 
+@dataclass(slots=True)
 class ServiceUser:
-    def __init__(self, name: str, display_name: str, id: str):
-        self.name = name
-        self.id = id
-        self.display_name = display_name
-        self.roles: list[ServiceRole] = []
+    name: str
+    display_name: str
+    id: str
+    roles: list[ServiceRole] = field(default_factory=list, init=False)
+    _user: object = field(default=None, init=False)
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, int):
             return self.id == other
-        if hasattr(self, "_user"):
-            if type(self._user) == type(other):
-                return self._user == other
+        if self._user is not None and type(self._user) == type(other):
+            return self._user == other
         if not isinstance(other, ServiceUser):
             return False
         return (self.id == other.id) and type(self) == type(other)
@@ -55,17 +54,17 @@ class ServiceUser:
         return str(self.id)
 
 
+@dataclass(slots=True)
 class ServiceServer:
-    def __init__(self, name: str, id: str):
-        self.name = name
-        self.id = id
+    name: str
+    id: str
+    _server: object = field(default=None, init=False)
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, int):
             return self.id == other
-        if hasattr(self, "_server"):
-            if type(self._server) == type(other):
-                return self._server == other
+        if self._server is None and type(self._server) == type(other):
+            return self._server == other
         if not isinstance(other, ServiceServer):
             return False
         return (self.id == other.id) and type(self) == type(other)
@@ -78,11 +77,12 @@ class ServiceServer:
         return hash(self.id) >> 22
 
 
+@dataclass(slots=True)
 class ServiceChannel:
-    def __init__(self, name: str, id: str, server: Optional[ServiceServer]):
-        self.id = id
-        self.name = name
-        self.server = server
+    name: str
+    id: str
+    server: Optional[ServiceServer]
+    _channel: object = field(default=None, init=False)
 
     def __repr__(self):
         return f"ServiceChannel({self.id})"
@@ -90,9 +90,8 @@ class ServiceChannel:
     def __eq__(self, other: object) -> bool:
         if isinstance(other, int):
             return self.id == other
-        if hasattr(self, "_channel"):
-            if type(self._channel) == type(other):
-                return self._channel == other
+        if self._channel and type(self._channel) == type(other):
+            return self._channel == other
         if not isinstance(other, ServiceChannel):
             return False
         return (self.id == other.id) and type(self) == type(other)
@@ -108,31 +107,28 @@ class ServiceChannel:
         raise NotImplementedError()
 
 
+@dataclass(slots=True)
 class ServiceMessage:
-    def __init__(
-        self, id: str, content: str, author: ServiceUser, channel: ServiceChannel, service: Services
-    ):
-        self.content = content
-        self.author = author
-        self.channel = channel
-        self.service = service
-        self.clean_content = content
-        self.service = service
-        self.created_at = datetime.now(timezone.utc)
-        self.id = id
-        self.mentions: list[ServiceUser] = []
-        self.reference: Optional[ServiceMessage] = None
-        self.is_dm = False
-
+    id: str
+    content: str
+    author: ServiceUser
+    channel: ServiceChannel
+    service: Services
+    clean_content: str = field(default="", init=False)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc), init=False)
+    mentions: list[ServiceUser] = field(default_factory=list, init=False)
+    reference: Optional["ServiceMessage"] = field(default=None, init=False)
+    is_dm: bool = field(default=False, init=False)
+    _message: object = field(default=None, init=False)
+    
     def __repr__(self):
         return f"ServiceMessage({self.content})"
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, int):
             return self.id == other
-        if hasattr(self, "_message"):
-            if type(self._message) == type(other):
-                return self._message == other
+        if self._message is not None and type(self._message) == type(other):
+            return self._message == other
         if not isinstance(other, ServiceMessage):
             return False
         return (self.id == other.id) and type(self) == type(other)


### PR DESCRIPTION
I changed classes in serviceutils.py into dataclasses with slots. I think this improves readability a bit and explicit information about types of attributes makes it possible to use static type checkers (e.g. pylint, mypy) to prevent runtime errors.

Alternatively, one could just add [__slots__](https://www.geeksforgeeks.org/slots-in-python/) to the class, list all attributes there, and provide type information in the definition, while preserving the init but I think using dataclass is makes it more concise, even though these classes are not necessarily meant "mostly to just store data".