### PR TITLE
fix dereference method usage

### DIFF
--- a/modules/Silly.py
+++ b/modules/Silly.py
@@ -28,8 +28,8 @@ class Silly(Module):
         if text.lower().startswith("say "):
             return Response(
                 confidence=4,
-                text=self.utils.modules_dict["Factoids"].dereference(text.partition(" ")[2]) + "!",
-                why="%s told me to say it!" % who,
+                text=self.dereference(text.partition(" ")[2], who) + "!",
+                why=f"{who} told me to say it!",
             )
 
         # XKCD #37


### PR DESCRIPTION
from error log https://discord.com/channels/677546901339504640/1017527224540344380/1028521302417481728
* `TypeError: dereference() missing 1 required positional argument: 'who'`