### PR TITLE
Migrated wiki URI to new server.

### DIFF
--- a/config.py
+++ b/config.py
@@ -102,7 +102,7 @@ wolfram_token = getenv("WOLFRAM_TOKEN", default="null")
 slack_app_token = getenv("SLACK_APP_TOKEN", default="null")
 slack_bot_token = getenv("SLACK_BOT_TOKEN", default="null")
 
-wiki_config = {"uri": "https://stampy.ai/w/api.php", "user": "Stampy@stampy", "password": wiki_password}
+wiki_config = {"uri": "https://wiki.stampy.ai/w/api.php", "user": "Stampy@stampy", "password": wiki_password}
 
 
 stampy_control_channel_names = [


### PR DESCRIPTION
I noticed that the Wiki itself and Stampy were giving different answers to "How many questions are in queue?"  Strangely, Stampy and the old wiki *also* give different answers.  But the old and new server give different responses when a blank get request is sent, specifically, a blank page is returned on the old server so my thought is the API is turned off and the response Stampy is giving may be cached.

I personally don't know if the username and password were migrated over or not, but at least this will now point to the production wiki.